### PR TITLE
Enhance maintenance page with before/after gallery

### DIFF
--- a/src/components/BeforeAfter/BeforeAfter.css
+++ b/src/components/BeforeAfter/BeforeAfter.css
@@ -1,0 +1,47 @@
+.before-after {
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+.before-after-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.before-after-image {
+  position: relative;
+  overflow: hidden;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.before-after-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s ease;
+  background-color: #f0f5f0;
+}
+
+.before-after-image:hover img {
+  transform: scale(1.05);
+}
+
+.before-after-label {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  background-color: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  padding: 2px 6px;
+  font-size: 0.75rem;
+  border-radius: 4px;
+  pointer-events: none;
+}
+
+.before-after-desc {
+  margin-top: 0.5rem;
+  color: #555;
+  font-size: 0.95rem;
+}

--- a/src/components/BeforeAfter/BeforeAfter.jsx
+++ b/src/components/BeforeAfter/BeforeAfter.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import "./BeforeAfter.css";
+
+const BeforeAfter = ({ before, after, description }) => (
+  <div className="before-after">
+    <div className="before-after-container">
+      <div className="before-after-image">
+        <img src={before} alt="Before service" loading="lazy" />
+        <span className="before-after-label">Before</span>
+      </div>
+      <div className="before-after-image">
+        <img src={after} alt="After service" loading="lazy" />
+        <span className="before-after-label">After</span>
+      </div>
+    </div>
+    {description && <p className="before-after-desc">{description}</p>}
+  </div>
+);
+
+export default BeforeAfter;

--- a/src/pages/services/Maintenance.jsx
+++ b/src/pages/services/Maintenance.jsx
@@ -1,18 +1,36 @@
 import Header from "../../components/Header/header";
-import Gallery from "../../components/Gallery/Gallery";
+import BeforeAfter from "../../components/BeforeAfter/BeforeAfter";
+import "./maintenance.css";
 import m1 from "../../assets/before1.png";
 import m2 from "../../assets/after1.png";
 import m3 from "../../assets/before2.png";
 import m4 from "../../assets/after2.png";
 
-const Maintenance = () => {
-  const images = [m1, m2, m3, m4];
-  return (
-    <div className="service-detail">
-      <Header />
-      <h1>Maintenance Services</h1>
-      <Gallery images={images} />
-    </div>
-  );
-};
+const Maintenance = () => (
+  <div className="service-detail">
+    <Header />
+    <h1>Maintenance Services</h1>
+    <p className="intro">
+      NEF provides complete landscape care so your property always looks its
+      best. Our experienced team handles routine mowing, seasonal cleanups and
+      everything in between.
+    </p>
+    <ul className="offering-list">
+      <li>Weekly lawn mowing and edging</li>
+      <li>Mulching, pruning and bed maintenance</li>
+      <li>Spring and fall cleanups</li>
+      <li>Snow plowing during winter months</li>
+    </ul>
+    <BeforeAfter
+      before={m1}
+      after={m2}
+      description="Transforming overgrown lawns into manicured spaces."
+    />
+    <BeforeAfter
+      before={m3}
+      after={m4}
+      description="Detailed cleanup for a refreshed landscape."
+    />
+  </div>
+);
 export default Maintenance;

--- a/src/pages/services/maintenance.css
+++ b/src/pages/services/maintenance.css
@@ -1,0 +1,37 @@
+.service-detail {
+  padding: 2rem 1rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.service-detail h1 {
+  color: #2f4f2f;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.service-detail .intro {
+  text-align: center;
+  margin-bottom: 1.5rem;
+  font-size: 1rem;
+  color: #555;
+}
+
+.offering-list {
+  list-style: none;
+  padding: 0;
+  margin-bottom: 2rem;
+  display: grid;
+  gap: 0.75rem;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.offering-list li {
+  background: #ffffff;
+  border: 1px solid var(--border-gray);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}


### PR DESCRIPTION
## Summary
- add new `BeforeAfter` component for side-by-side photos
- style before/after images and maintenance services page
- rewrite Maintenance page with descriptions and before/after examples

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684461ad4cec8330b05f190bf1dfb3cb